### PR TITLE
Fix case of unreleased version title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed case of unreleased version to match http://keepachangelog.com/
+
 ## [0.6.2] - 2018-07-24
 
 ### Added
@@ -101,6 +107,7 @@ First version
 
 [#1]: https://github.com/oscarotero/keep-a-changelog/issues/1
 
+[Unreleased]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.2...HEAD
 [0.6.2]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/oscarotero/keep-a-changelog/compare/v0.5.2...v0.6.0

--- a/src/Release.js
+++ b/src/Release.js
@@ -103,9 +103,9 @@ class Release {
             }
         } else {
             if (this.hasCompareLink(changelog)) {
-                t.push('## [UNRELEASED]');
+                t.push('## [Unreleased]');
             } else {
-                t.push('## UNRELEASED');
+                t.push('## Unreleased');
             }
         }
 
@@ -142,7 +142,7 @@ class Release {
         }
 
         if (!this.version) {
-            return `[UNRELEASED]: ${changelog.url}/compare/v${
+            return `[Unreleased]: ${changelog.url}/compare/v${
                 next.version
             }...HEAD`;
         }
@@ -193,7 +193,7 @@ module.exports = Release;
 
 function formatDate(date) {
     if (!date) {
-        return 'UNRELEASED';
+        return 'Unreleased';
     }
 
     let year = date.getUTCFullYear(),

--- a/test/changelog.expected.md
+++ b/test/changelog.expected.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [Unreleased]
 
 ### Added
 
 - Test
 
-## [2.0.0] - UNRELEASED
+## [2.0.0] - Unreleased
 
 ### Added
 
@@ -186,7 +186,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#3]: https://github.com/olivierlacan/keep-a-changelog/issues/3
 [#4]: https://github.com/olivierlacan/keep-a-changelog/issues/4
 
-[UNRELEASED]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
 [2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
Following https://keepachangelog.com/en/1.0.0/ , the unreleased version should be titled `Unreleased` instead of `UNRELEASED`.  This PR changes the case of the title to reflect that.