### PR TITLE
Fix trailing newlines when no links are present

### DIFF
--- a/src/Changelog.js
+++ b/src/Changelog.js
@@ -56,13 +56,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).`;
             }
         });
 
-        t.push('');
+        if (links.length) {
+            t.push('');
 
-        links.forEach(link => t.push(link));
+            links.forEach(link => t.push(link));
+        }
 
-        t.push('');
+        if (compareLinks.length) {
+            t.push('');
 
-        compareLinks.forEach(link => t.push(link));
+            compareLinks.forEach(link => t.push(link));
+        }
 
         t.push('');
 

--- a/test/empty.expected.md
+++ b/test/empty.expected.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+and this project adheres to [Semantic Versioning](http://semver.org/).

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,19 @@
 const fs = require('fs');
-const { parser } = require('../src');
+const { parser, Changelog } = require('../src');
 const assert = require('assert');
 
 const changelog = parser(fs.readFileSync(__dirname + '/changelog.md', 'UTF-8'));
 const expected = fs.readFileSync(__dirname + '/changelog.expected.md', 'UTF-8');
+const emptyExpected = fs.readFileSync(__dirname + '/empty.expected.md', 'UTF-8');
 
 //fs.writeFileSync(__dirname + '/changelog.expected.md', changelog.toString());
 // console.log(changelog.toString());
 
 describe('Changelog testing', function() {
+    it('should generate an empty changelog', function() {
+        assert.equal(new Changelog('Changelog').toString(), emptyExpected);
+    });
+
     it('should match the generated changelog with the expected', function() {
         assert.equal(changelog.toString().trim(), expected.trim());
     });


### PR DESCRIPTION
This PR fixes an issue where there are multiple consecutive trailing newlines for newly created 
Changelogs or Changelogs without links (or compare links).