### PR TITLE
Add functions for finding a release by version and for changing a release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- `findRelease` function on `Changelog` to find a release by version number
+- `setVersion` function on `Release` to change the version of a release
+
 ## [0.6.3] - 2018-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [0.6.4] - 2018-09-03
 
 ### Added
 
-- `findRelease` function on `Changelog` to find a release by version number
-- `setVersion` function on `Release` to change the version of a release
+- Added `findRelease` function to `Changelog` for finding a release by version number - [#6]
+- Added `setVersion` function to `Release` for changing the version of a release - [#6]
 
 ## [0.6.3] - 2018-08-22
 
@@ -114,11 +114,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First version
 
+[#6]: https://github.com/oscarotero/keep-a-changelog/issues/6
 [#5]: https://github.com/oscarotero/keep-a-changelog/issues/5
 [#4]: https://github.com/oscarotero/keep-a-changelog/issues/4
 [#3]: https://github.com/oscarotero/keep-a-changelog/issues/3
 [#1]: https://github.com/oscarotero/keep-a-changelog/issues/1
 
+[0.6.4]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/oscarotero/keep-a-changelog/compare/v0.6.0...v0.6.1

--- a/example.js
+++ b/example.js
@@ -64,6 +64,11 @@ const changelog = new Changelog('Changelog')
             .fixed('Fixed case of unreleased version to match http://keepachangelog.com/ - #4')
             .fixed('Fixed Release isEmpty and add tests - #3')
     )
+    .addRelease(
+        new Release('0.6.4', '2018-09-03')
+            .added('Added `findRelease` function to `Changelog` for finding a release by version number - #6')
+            .added('Added `setVersion` function to `Release` for changing the version of a release - #6')
+    )
 
 changelog.url = 'https://github.com/oscarotero/keep-a-changelog';
 

--- a/src/Changelog.js
+++ b/src/Changelog.js
@@ -1,4 +1,5 @@
 const Release = require('./Release');
+const Semver = require('semver');
 
 class Changelog {
     constructor(title, description = '') {
@@ -15,10 +16,21 @@ class Changelog {
         }
 
         this.releases.push(release);
-        this.releases.sort((a, b) => a.compare(b));
+        this.sortReleases();
         release.changelog = this;
 
         return this;
+    }
+
+    findRelease(version) {
+        if (!version) {
+            return this.releases.find(release => !release.version)
+        }
+        return this.releases.find(release => release.version && Semver.eq(release.version, version))
+    }
+
+    sortReleases() {
+        this.releases.sort((a, b) => a.compare(b));
     }
 
     toString() {

--- a/src/Changelog.js
+++ b/src/Changelog.js
@@ -24,9 +24,11 @@ class Changelog {
 
     findRelease(version) {
         if (!version) {
-            return this.releases.find(release => !release.version)
+            return this.releases.find(release => !release.version);
         }
-        return this.releases.find(release => release.version && Semver.eq(release.version, version))
+        return this.releases.find(
+            release => release.version && Semver.eq(release.version, version)
+        );
     }
 
     sortReleases() {

--- a/src/Release.js
+++ b/src/Release.js
@@ -3,15 +3,12 @@ const Change = require('./Change');
 
 class Release {
     constructor(version, date, description = '') {
-        if (typeof version === 'string') {
-            version = new Semver(version);
-        }
+        this.setVersion(version);
 
         if (typeof date === 'string') {
             date = new Date(date);
         }
 
-        this.version = version;
         this.date = date;
         this.description = description;
         this.changes = new Map([
@@ -52,6 +49,17 @@ class Release {
         return Array.from(this.changes.values()).every(change => !change.length);
     }
 
+    setVersion (version) {
+        if (typeof version === 'string') {
+            version = new Semver(version);
+        }
+        this.version = version;
+        //Re-sort the releases of the parent changelog
+        if (this.changelog) {
+            this.changelog.sortReleases();
+        }
+    }
+
     addChange(type, change) {
         if (!(change instanceof Change)) {
             change = new Change(change);
@@ -65,6 +73,7 @@ class Release {
 
         return this;
     }
+    
 
     added(change) {
         return this.addChange('added', change);

--- a/src/Release.js
+++ b/src/Release.js
@@ -49,7 +49,7 @@ class Release {
         return Array.from(this.changes.values()).every(change => !change.length);
     }
 
-    setVersion (version) {
+    setVersion(version) {
         if (typeof version === 'string') {
             version = new Semver(version);
         }
@@ -73,7 +73,6 @@ class Release {
 
         return this;
     }
-    
 
     added(change) {
         return this.addChange('added', change);

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,47 @@ describe('Changelog testing', function() {
     it('should match the generated changelog with the expected', function() {
         assert.equal(changelog.toString().trim(), expected.trim());
     });
+
+    describe('findRelease', function() {
+        it('should find an Unreleased release if no argument is passed in', function() {
+            const changelog = new Changelog('Changelog');
+            const unreleased = new Release();
+            const versioned = new Release('1.2.3');
+            changelog.addRelease(unreleased).addRelease(versioned);
+            assert.equal(changelog.findRelease(), unreleased);
+        });
+
+        it('should find an Unreleased release if null is passed in', function() {
+            const changelog = new Changelog('Changelog');
+            const unreleased = new Release();
+            const versioned = new Release('1.2.3');
+            changelog.addRelease(unreleased).addRelease(versioned);
+            assert.equal(changelog.findRelease(null), unreleased);
+        });
+
+        it('should return undefined when there is no Unreleased release', function() {
+            const changelog = new Changelog('Changelog');
+            const versioned = new Release('1.2.3');
+            changelog.addRelease(versioned);
+            assert.equal(changelog.findRelease(null), undefined);
+        });
+
+        it('should find the given release', function() {
+            const changelog = new Changelog('Changelog');
+            const unreleased = new Release();
+            const versioned = new Release('1.2.3');
+            changelog.addRelease(unreleased).addRelease(versioned);
+            assert.equal(changelog.findRelease('1.2.3'), versioned);
+        });
+
+        it('should return undefined for a non-existent release', function() {
+            const changelog = new Changelog('Changelog');
+            const unreleased = new Release();
+            const versioned = new Release('1.2.3');
+            changelog.addRelease(unreleased).addRelease(versioned);
+            assert.equal(changelog.findRelease('1.0.0'), undefined);
+        });
+    });
 });
 
 describe('Release testing', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -104,17 +104,17 @@ describe('Release testing', function() {
             assert.equal(release.version.toString(), '1.2.3');
         });
 
-        it('should sort the parent changelog\'s releases', function() {
+        it("should sort the parent changelog's releases", function() {
             const release = new Release('1.2.2');
             let sortCalled = false;
             release.changelog = {
                 sortReleases() {
-                    sortCalled = true
+                    sortCalled = true;
                 }
             };
             assert.equal(sortCalled, false);
             release.setVersion('1.2.3');
             assert.equal(sortCalled, true);
-        })
+        });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const { parser, Changelog, Release } = require('../src');
 const assert = require('assert');
+const Semver = require('semver');
 
 const changelog = parser(fs.readFileSync(__dirname + '/changelog.md', 'UTF-8'));
 const expected = fs.readFileSync(__dirname + '/changelog.expected.md', 'UTF-8');
@@ -42,5 +43,37 @@ describe('Release testing', function() {
             assert.equal(new Release().fixed('fixed').isEmpty(), false);
             assert.equal(new Release().security('security').isEmpty(), false);
         });
+    });
+
+    describe('setVersion', function() {
+        it('should update the version of a null-version release', function() {
+            const release = new Release();
+            assert.equal(release.version, undefined);
+            release.setVersion('1.2.3');
+            assert.equal(release.version instanceof Semver, true);
+            assert.equal(release.version.toString(), '1.2.3');
+        });
+
+        it('should update the version of a versioned release', function() {
+            const release = new Release('1.2.2');
+            assert.equal(release.version instanceof Semver, true);
+            assert.equal(release.version.toString(), '1.2.2');
+            release.setVersion('1.2.3');
+            assert.equal(release.version instanceof Semver, true);
+            assert.equal(release.version.toString(), '1.2.3');
+        });
+
+        it('should sort the parent changelog\'s releases', function() {
+            const release = new Release('1.2.2');
+            let sortCalled = false;
+            release.changelog = {
+                sortReleases() {
+                    sortCalled = true
+                }
+            };
+            assert.equal(sortCalled, false);
+            release.setVersion('1.2.3');
+            assert.equal(sortCalled, true);
+        })
     });
 });


### PR DESCRIPTION
This PR adds the following functions:

- `Changelog.prototype.findRelease` - finds a release by version number
- `Release.prototype.setVersion` - updates a release's version (and re-sorts the releases in the changelog)

Tests were added for `setVersion`, and I can add tests for `findRelease` as well if you want