### PR TITLE
Update issue regexes to prevent unwanted extractions

### DIFF
--- a/src/Change.js
+++ b/src/Change.js
@@ -1,8 +1,8 @@
 class Change {
     constructor(title, description = '') {
         this.issues = [];
-        this.title = extractIssues(title, this.issues);
-        this.description = extractIssues(description, this.issues);
+        this.title = Change.extractIssues(title, this.issues);
+        this.description = Change.extractIssues(description, this.issues);
     }
 
     toString() {
@@ -21,20 +21,20 @@ class Change {
 
 module.exports = Change;
 
-function extractIssues(text, issues) {
+Change.extractIssues = function(text, issues) {
     return text
-        .replace(/\[#(\d+)\]([^\(]|$)/g, (matches, index, end) => {
+        .replace(/(^|[^\\])\[#(\d+)\](?=[^\(]|$)/g, (matches, start, index) => {
             if (!issues.includes(index)) {
                 issues.push(index);
             }
 
-            return `[#${index}]${end}`;
+            return `${start}[#${index}]`;
         })
-        .replace(/#(\d+)([^\w\]\.]|[^\d\w\]]?$)/g, (matches, index, end) => {
+        .replace(/(^|[\s,])#(\d+)(?=[\s,\.]|$)/g, (matches, start, index) => {
             if (!issues.includes(index)) {
                 issues.push(index);
             }
 
-            return `[#${index}]${end}`;
+            return `${start}[#${index}]`;
         });
-}
+};

--- a/test/Change.js
+++ b/test/Change.js
@@ -1,0 +1,93 @@
+const Change = require('../src/Change');
+const assert = require('assert');
+
+describe('Change testing', function() {
+    describe('extractIssues', function() {
+        it('should extract issues from text', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - #777', issues);
+            assert.equal(text, 'some change - [#777]');
+            assert.ok(issues.includes('777'));
+        });
+
+        it('should extract multiple issues', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - #777, #778', issues);
+            assert.equal(text, 'some change - [#777], [#778]');
+            assert.ok(issues.includes('777'));
+            assert.ok(issues.includes('778'));
+        });
+
+        it('should extract issues with brackets', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - [#777]', issues);
+            assert.equal(text, 'some change - [#777]');
+            assert.ok(issues.includes('777'));
+        });
+
+        it('should not extract issues which are part of a link', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - [#777](https://example.com)', issues);
+            assert.equal(text, 'some change - [#777](https://example.com)');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should extract issues with a period after them', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - #777. [#778].', issues);
+            assert.equal(text, 'some change - [#777]. [#778].');
+            assert.ok(issues.includes('777'));
+            assert.ok(issues.includes('778'));
+        });
+
+        it('should not extract issues which are escaped', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - \\#777, \\[#778], [\\#779]', issues);
+            assert.equal(text, 'some change - \\#777, \\[#778], [\\#779]');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should not extract issues which are in code', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - `#777`', issues);
+            assert.equal(text, 'some change - `#777`');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should not extract issues which are not preceded by whitespace or commas', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change#777', issues);
+            assert.equal(text, 'some change#777');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should extract issues which are separated by a comma', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change #777,#778', issues);
+            assert.equal(text, 'some change [#777],[#778]');
+            assert.ok(issues.includes('777'));
+            assert.ok(issues.includes('778'));
+        });
+
+        it('should not extract issues which include non-numeric characters', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - #77a', issues);
+            assert.equal(text, 'some change - #77a');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should not extract issues which are inside parentheses without brackets', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - (#777)', issues);
+            assert.equal(text, 'some change - (#777)');
+            assert.deepEqual(issues, []);
+        });
+
+        it('should extract issues which are inside parentheses with brackets', function() {
+            const issues = [];
+            const text = Change.extractIssues('some change - ([#777])', issues);
+            assert.equal(text, 'some change - ([#777])');
+            assert.ok(issues.includes('777'));
+        });
+    });
+});


### PR DESCRIPTION
This PR updates the regular expressions used in `extractIssues` to narrow down issue extraction and prevent unwanted extraction of issues.  This has started to come up often in our use of keep-a-changelog around CSS color values which only involve numbers (i.e. #888888).  Issues are now extracted using stricter rules.

- Issues with brackets
  - Always extracted unless the leading bracket is escaped or the brackets are already part of a link.
- Issues without brackets
  - Must be preceded by whitespace or a comma (or be at the start of the line)
  - Must be followed by whitespace, a comma, or a period (or be at the end of the line)

Also added a lot of test cases around issue extraction which should hopefully cover most possibilities.

Resolves https://github.com/brightcove/kacl/issues/11