### PR TITLE
Improve error message for release titles missing dates

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -111,9 +111,12 @@ function tokenize(markdown) {
                 return ['h3', [line.substr(3).trim()]];
             }
 
-            const li = /^\s*[-\*]\s+(.*)/.exec(line);
-            if (li) {
-                return ['li', [li[1]]];
+            if (line.startsWith('-')) {
+                return ['li', [line.substr(1).trim()]];
+            }
+
+            if (line.startsWith('*')) {
+                return ['li', [line.substr(1).trim()]];
             }
 
             if (line.match(/^\[.*\]\:\s*http.*$/)) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -2,18 +2,18 @@ const assert = require('assert');
 const {parser} = require('../src');
 
 describe('Parser testing', function() {
-    it('should allow spaces before dashes and asterisks', function() {
+    it('should include nested bullets in title', function() {
         const changelog = parser([
             '# Changelog - demo',
             '## [1.0.0] - unreleased',
             '### Added',
-            '  - A cool feature',
+            '- A cool feature',
             '  * Something neat'
         ].join('\n'));
 
         assert.deepEqual(
             changelog.findRelease('1.0.0').changes.get('added').map(c => c.title),
-            ['A cool feature', 'Something neat']
+            ['A cool feature\n  * Something neat']
         );
     });
     it('should not consider lines with - in the middle as changes', function() {
@@ -21,13 +21,13 @@ describe('Parser testing', function() {
             '# Changelog - demo',
             '## [1.0.0] - unreleased',
             '### Added',
-            '  - A cool feature',
-            '    with multiple lines and a - in the middle',
+            '- A cool feature',
+            '  with multiple lines and a - in the middle',
         ].join('\n'));
 
         assert.deepEqual(
             changelog.findRelease('1.0.0').changes.get('added').map(c => c.title),
-            ['A cool feature\n    with multiple lines and a - in the middle']
+            ['A cool feature\n  with multiple lines and a - in the middle']
         );
     });
     it('should explain why a release is invalid ', function() {


### PR DESCRIPTION
Previously when a release title omitted a date, you would get the error
```
Parse error in the line 35: Syntax error in the release title
```
Now the error message is
```
Parse error in the line 35: Release title must contain release date in yyyy-mm-dd form
```