### PR TITLE
Added  setDate function to  for changing the date of a release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.7.0] - 2018-11-29

--- a/src/Release.js
+++ b/src/Release.js
@@ -4,12 +4,8 @@ const Change = require('./Change');
 class Release {
     constructor(version, date, description = '') {
         this.setVersion(version);
+        this.setDate(date);
 
-        if (typeof date === 'string') {
-            date = new Date(date);
-        }
-
-        this.date = date;
         this.description = description;
         this.changes = new Map([
             ['added', []],
@@ -58,6 +54,13 @@ class Release {
         if (this.changelog) {
             this.changelog.sortReleases();
         }
+    }
+
+    setDate(date) {
+        if (typeof date === 'string') {
+            date = new Date(date);
+        }
+        this.date = date;
     }
 
     addChange(type, change) {

--- a/test/index.js
+++ b/test/index.js
@@ -117,4 +117,29 @@ describe('Release testing', function() {
             assert.equal(sortCalled, true);
         });
     });
+
+    describe('setDate', function() {
+        it('should update the date of a null-date release', function() {
+            const release = new Release();
+            assert.equal(release.version, undefined);
+            release.setDate('2019-02-02');
+            assert.equal(release.date instanceof Date, true);
+            assert.equal(release.date.getUTCFullYear(), 2019);
+            assert.equal(release.date.getUTCMonth() + 1, 2);
+            assert.equal(release.date.getUTCDate(), 2);
+        });
+
+        it('should update the date of a dated release', function() {
+            const release = new Release('1.2.3', '2018-05-05');
+            assert.equal(release.date instanceof Date, true);
+            assert.equal(release.date.getUTCFullYear(), 2018);
+            assert.equal(release.date.getUTCMonth() + 1, 5);
+            assert.equal(release.date.getUTCDate(), 5);
+            release.setDate('2019-02-02');
+            assert.equal(release.date instanceof Date, true);
+            assert.equal(release.date.getUTCFullYear(), 2019);
+            assert.equal(release.date.getUTCMonth() + 1, 2);
+            assert.equal(release.date.getUTCDate(), 2);
+        });
+    });
 });


### PR DESCRIPTION
Similar to setVersion, this PR adds a setDate function in order to allow setting the date of an existing release.

My use case scenario is that I have an [Unreleased] release which doesn't have a date, and I'd like to programmatically promote this Unreleased version into a proper version with semver and also with the date specified.