### PR TITLE
Ability to add new Change Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- documentation to extend `Release` class + test coverage
+- ability to use extended `Release` within `parser`
 
 ## [0.9.1] - 2019-11-26
 ### Fixed
@@ -138,6 +143,7 @@ First version
 [#9]: https://github.com/oscarotero/keep-a-changelog/issues/9
 [#10]: https://github.com/oscarotero/keep-a-changelog/issues/10
 
+[Unreleased]: https://github.com/oscarotero/keep-a-changelog/compare/v0.9.1...HEAD
 [0.9.1]: https://github.com/oscarotero/keep-a-changelog/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/oscarotero/keep-a-changelog/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/oscarotero/keep-a-changelog/compare/v0.8.1...v0.8.2

--- a/README.md
+++ b/README.md
@@ -55,6 +55,41 @@ By default, the tag names are `v` + version number. For example, the tag for the
 const changelog = new Changelog();
 changelog.tagNameBuilder = release => `version-${release.version}`;
 ```
+### Custom Change Types
+
+By default and according to the [keepachangelog](http://keepachangelog.com/en/1.0.0/) format, the change types are
+`Added`,
+`Changed`,
+`Deprecated`,
+`Removed`,
+`Fixed`,
+and `Security`.
+In case you'd like add another type in order to use is in your changelog, you basically need to extend the `Release` class to support new types. Additionally, you have to tell the `parser` that it should create instances of your new extended `Release` in order to parse your changelog correctly.
+
+For example, we would like to add a type `Maintenance`.
+Extend the provided `Release` class:
+```js
+class CustomRelease extends Release {
+    constructor(version, date, description) {
+        super(version, date, description);
+        // add whatever types you want - in lowercase
+        const newChangeTypes = [
+            ['maintenance', []]
+        ];
+
+        this.changes = new Map([...this.changes, ...newChangeTypes]);
+    }
+    // for convenience, add a new method to add change of type 'maintanance'
+    maintenance(change) {
+        return this.addChange('maintenance', change);
+    }
+}
+```
+And once you want to use the parser:
+```js
+const releaseCreator = (ver, date, desc) => new CustomRelease(ver, date, desc)
+const changelog = parser(changelogTextContent, {releaseCreator})
+```
 
 ## Cli
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^1.19.1"
   },
   "scripts": {
-    "prettier": "prettier src/*.js test/*.js bin.js --single-quote --tab-width 4 --print-width 100 --write",
+    "prettier": "prettier src/*.js test/**/*.js bin.js --single-quote --tab-width 4 --print-width 100 --write",
     "test": "mocha test",
     "changelog": "node example.js"
   }

--- a/test/changelog.custom.type.md
+++ b/test/changelog.custom.type.md
@@ -1,0 +1,22 @@
+# Changelog - demo
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Maintenance
+- upgrade
+- fix vulnerabilities
+
+## [2.0.0] - 2020-02-07
+### Added
+- custom release
+
+## 1.0.0 - 2020-02-06
+### Maintenance
+- fix naming
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v2.0.0

--- a/test/fixture/CustomRelease.js
+++ b/test/fixture/CustomRelease.js
@@ -1,0 +1,20 @@
+const { Release } = require('../../src');
+
+class CustomRelease extends Release {
+    constructor(version, date, description) {
+        super(version, date, description);
+
+        const newChangeTypes = [['maintenance', []]];
+
+        this.changes = new Map([...this.changes, ...newChangeTypes]);
+    }
+    maintenance(change) {
+        return this.addChange('maintenance', change);
+    }
+}
+
+module.exports = {
+    customReleaseCreator: function(version, date, description) {
+        return new CustomRelease(version, date, description);
+    }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const { parser, Changelog, Release } = require('../src');
+const { customReleaseCreator } = require('./fixture/CustomRelease');
 const assert = require('assert');
 const Semver = require('semver');
 
@@ -140,6 +141,24 @@ describe('Release testing', function() {
             assert.equal(release.date.getUTCFullYear(), 2019);
             assert.equal(release.date.getUTCMonth() + 1, 2);
             assert.equal(release.date.getUTCDate(), 2);
+        });
+    });
+    describe('extending Release with custom type: Maintenance', function() {
+        it('adds a change with a new method maintenance()', function() {
+            assert.equal(customReleaseCreator().maintenance('maintenance').isEmpty(), false);
+        });
+        it('creates release entry with Maintanace subsection', function() {
+            const release = customReleaseCreator()
+                .maintenance('upgrade')
+                .maintenance('fix vulnerabilities');
+            const expectedResult = [
+                '## Unreleased',
+                '### Maintenance',
+                '- upgrade',
+                '- fix vulnerabilities'
+            ].join('\n');
+
+            assert.equal(release.toString(), expectedResult);
         });
     });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const { parser } = require('../src');
+const { customReleaseCreator } = require('./fixture/CustomRelease');
+const changelogContent = fs.readFileSync(__dirname + '/changelog.custom.type.md', 'UTF-8')
+
+describe('parser testing', function() {
+    it('is unable to parse changelog with unknown types', function() {
+        const throwingReleaseCreatedByParser = function() {
+            parser(changelogContent);
+        };
+
+        assert.throws(throwingReleaseCreatedByParser);
+    });
+    it('parses a changelog with custom types using a custom releaseCreator', function() {
+        const changelog = parser(changelogContent, {releaseCreator: customReleaseCreator})
+        assert.equal(changelog.toString().trim(), changelogContent.trim());
+    });
+});


### PR DESCRIPTION
 - extend `Release` class
 - test extended Release
 - parser change + test parser with custom release
 - update readme + changelog

I'm not sure who is actually using the code, but I tried avoiding new JS stuff, like arrow functions or object destructuring so it work with older versions of Node.