### PR TITLE
Issue #16: recognize and parse two-line reference links

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -96,7 +96,7 @@ function tokenize(markdown) {
     markdown
         .trim()
         .split('\n')
-        .map((line) => {
+        .map((line, index, allLines) => {
             if (line.startsWith('---')) {
                 return ['hr', ['-']];
             }
@@ -123,6 +123,14 @@ function tokenize(markdown) {
 
             if (line.match(/^\[.*\]\:\s*http.*$/)) {
                 return ['link', [line.trim()]];
+            }
+            if (line.match(/^\[.*\]\:$/)) {
+                const nextLine = allLines[index + 1];
+                if (nextLine && nextLine.match(/\s+http.*$/)) {
+                    // We found a multi-line link: treat it like a single line
+                    allLines[index + 1] = '';
+                    return ['link', [line.trim() + '\n' + nextLine.trim()]];
+                }
             }
 
             return ['p', [line.trimEnd()]];

--- a/src/parser.js
+++ b/src/parser.js
@@ -129,7 +129,7 @@ function tokenize(markdown) {
                 if (nextLine && nextLine.match(/\s+http.*$/)) {
                     // We found a multi-line link: treat it like a single line
                     allLines[index + 1] = '';
-                    return ['link', [line.trim() + '\n' + nextLine.trim()]];
+                    return ['link', [line.trim() + '\n' + nextLine.trimEnd()]];
                 }
             }
 

--- a/test/changelog.md
+++ b/test/changelog.md
@@ -146,9 +146,12 @@ notable changes.
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
-[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[Unreleased]:
+  https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.0]:
+  https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]:
+  https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
 [0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
 const fs = require('fs');
+const prettier = require('prettier');
 
 const { parser } = require('../src');
 const { customReleaseCreator } = require('./fixture/CustomRelease');
 const changelogContent = fs.readFileSync(__dirname + '/changelog.custom.type.md', 'UTF-8')
+const changelogText = fs.readFileSync(__dirname + '/changelog.md', 'UTF-8');
 
 describe('parser testing', function() {
     it('is unable to parse changelog with unknown types', function() {
@@ -16,5 +18,15 @@ describe('parser testing', function() {
     it('parses a changelog with custom types using a custom releaseCreator', function() {
         const changelog = parser(changelogContent, {releaseCreator: customReleaseCreator})
         assert.equal(changelog.toString().trim(), changelogContent.trim());
+    });
+    it('parses a Prettier-formatted changelog the same as the original', function() {
+        const originalChangelog = parser(changelogText);
+        const reformattedText = prettier.format(changelogText, {
+            parser: 'markdown',
+        })
+        const reformattedChangelog = parser(reformattedText);
+
+        assert.notEqual(changelogText.trim(), reformattedText.trim());
+        assert.equal(originalChangelog.toString().trim(), reformattedChangelog.toString().trim());
     });
 });


### PR DESCRIPTION
Detect and handle cases where the URL for a reference link is on the line after its label. This situation is created by using Prettier to format a Changelog file.

Discussion: https://github.com/oscarotero/keep-a-changelog/issues/16