### PR TITLE
Fixes for release args

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -8,6 +8,7 @@ import { parse as parseIni } from "https://deno.land/x/ini@v2.1.0/mod.ts";
 const argv = parseFlag(Deno.args, {
   default: {
     file: "CHANGELOG.md",
+    release: null,
     url: null,
     https: true,
     quiet: false,

--- a/bin.ts
+++ b/bin.ts
@@ -30,7 +30,7 @@ try {
 
   const changelog = parser(Deno.readTextFileSync(file));
 
-  if (argv.latestRelease) {
+  if (argv['latest-release']) {
     const release = changelog.releases.find((release) =>
       release.date && release.version
     );


### PR DESCRIPTION
The `--latest-release` arg was not functioning, due to mismatch of the arg as parsed and the argv property.

also added the release flag to the spec as it wasn't in there, but the code looking for it is.