### PR TITLE
Sanitize result of GetRemoteUrl

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -148,7 +148,9 @@ function getRemoteUrl(https = true) {
       remoteUrl.protocol = "https:";
     }
 
-    return remoteUrl.href;
+    // remove trailing slashes
+    var sanitizedUrl = remoteUrl.href.replace(/\/+$/, "")
+    return sanitizedUrl;
   } catch (err) {
     console.error(red(err.message));
     // Ignore

--- a/bin.ts
+++ b/bin.ts
@@ -149,8 +149,7 @@ function getRemoteUrl(https = true) {
     }
 
     // remove trailing slashes
-    var sanitizedUrl = remoteUrl.href.replace(/\/+$/, "")
-    return sanitizedUrl;
+    return remoteUrl.href.replace(/\/+$/, "");
   } catch (err) {
     console.error(red(err.message));
     // Ignore


### PR DESCRIPTION
If a repository was cloned by `git clone https://github.com/oscarotero/keep-a-changelog/` (note the trailing slash) the fetched remote url contains a trailing slash and leads to links with 2 slashes.