### PR TITLE
Fix uncomplete call to save() during init

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -30,7 +30,7 @@ try {
 
     changelog.format = argv.format as "compact" | "markdownlint";
 
-    save(file, changelog, true);
+    save(file, changelog, true, argv.head);
     Deno.exit(0);
   }
 


### PR DESCRIPTION
I am not sure if this is really required, since the newly initialized changelog does not contain any links.