### PR TITLE
Fix changelog parser for gitlab links

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,7 +83,7 @@ function processTokens(tokens: Token[], opts: Options): Changelog {
 
   while (link) {
     if (!changelog.url) {
-      const matches = link.match(/^\[.*\]\:\s*(http.*)\/compare\/.*$/);
+      const matches = link.match(/^\[.*\]\:\s*(http.*)\/(?:-\/)?compare\/.*$/);
 
       if (matches) {
         changelog.url = matches[1];


### PR DESCRIPTION
`GitLab` compare links contain a dash, the dash was not correctly removed from the base url and this leads to incremented dashes in the compare and tag links.


On the other hand we also could sanitize the links somewhere else.