### PR TITLE
Fix regex for GitLab links in parser.ts

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,7 +83,7 @@ function processTokens(tokens: Token[], opts: Options): Changelog {
 
   while (link) {
     if (!changelog.url) {
-      const matches = link.match(/^\[.*\]\:\s*(http.*)\/(?:-\/)?compare\/.*$/);
+      const matches = link.match(/^\[.*\]\:\s*(http.*?)\/(?:-\/)?compare\/.*$/);
 
       if (matches) {
         changelog.url = matches[1];

--- a/test/changelog.gitlab.md
+++ b/test/changelog.gitlab.md
@@ -1,0 +1,24 @@
+# Changelog - gitlab demo
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+- This is a brand new releases with:
+
+## [0.0.2] - 2023-11-09
+### Added
+- I want to have a compare link
+
+## [0.0.1] - 2023-11-09
+### Added
+- This is just a test changelog
+
+[Unreleased]: https://gitlab.example.com/my/repo/-/compare/v0.0.2...master
+[0.0.2]: https://gitlab.example.com/my/repo/-/compare/v0.0.1...v0.0.2
+[0.0.1]: https://gitlab.example.com/my/repo/-/tags/v0.0.1
+
+---
+
+This is a footer

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,9 +1,12 @@
-import { assertEquals, assertThrows } from "./deps.ts";
+import { assertEquals, assertNotEquals, assertThrows } from "./deps.ts";
 import { parser } from "../mod.ts";
 import releaseCreator from "./fixture/CustomRelease.ts";
+import getSettingsForURL from "../src/settings.ts";
 
 const file = new URL("./changelog.custom.type.md", import.meta.url).pathname;
+const fileGitlab = new URL("./changelog.gitlab.md", import.meta.url).pathname;
 const changelogContent = Deno.readTextFileSync(file);
+const changelogContentGitlab = Deno.readTextFileSync(fileGitlab);
 
 Deno.test("parser testing", function () {
   // is unable to parse changelog with unknown types
@@ -13,4 +16,22 @@ Deno.test("parser testing", function () {
   const changelog = parser(changelogContent, { releaseCreator });
 
   assertEquals(changelog.toString().trim(), changelogContent.trim());
+});
+
+Deno.test("parser testing gitlab", function () {
+  // parses a changelog with gitlab links
+  const changelog = parser(changelogContentGitlab, );
+
+  // get settings from url
+  assertNotEquals(changelog.url, undefined)
+  if(changelog.url) {
+    const settings = getSettingsForURL(changelog.url);
+    assertNotEquals(settings, undefined)
+    if(settings) {
+      changelog.head = settings.head;
+      changelog.tagLinkBuilder = settings.tagLink;
+    }
+  }
+
+  assertEquals(changelog.toString().trim(), changelogContentGitlab.trim());
 });


### PR DESCRIPTION
The first group used a greedy match, so that it always matched the dash that gitlab uses in front of `compare`. The optional group was not enough to remove the dash from the matched link.

I am so sorry for the broken merge requests. I added a test to avoid further broken releases.