### PR TITLE
Improve URL normalization in bin.ts

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -130,6 +130,20 @@ function green(message: string) {
   return "\u001b[" + 32 + "m" + message + "\u001b[" + 39 + "m";
 }
 
+function normalizeUrl(url: string, https: boolean) {
+  // remove .git suffix
+  url = url.replace(".git", "")
+
+  // normalize git@host urls
+  if (url.startsWith("git@")) {
+    url = url.replace(/^git@([^:]+):(.*)$/, (https ? "https" : "http") + "://$1/$2");
+  }
+
+  // remove trailing slashes
+  url = url.replace(/\/+$/, "")
+  return new URL(url)
+}
+
 function getRemoteUrl(https = true) {
   try {
     const file = join(Deno.cwd(), ".git", "config");
@@ -141,16 +155,7 @@ function getRemoteUrl(https = true) {
       return;
     }
 
-    const remoteUrl = new URL(
-      url.replace(/^git@([^:]+):(.*)\.git$/, "https://$1/$2"),
-    );
-
-    if (https) {
-      remoteUrl.protocol = "https:";
-    }
-
-    // remove trailing slashes
-    return remoteUrl.href.replace(/\/+$/, "");
+    return normalizeUrl(url, https).href;
   } catch (err) {
     console.error(red(err.message));
     // Ignore


### PR DESCRIPTION
The original implementation did not handle https URLs. If one cloned a repository via https://github.com/my/project.git the URL in `CHANGELOG.md` still contained the .git suffix. This is only a issue if a new `CHANGELOG.md` file is created by `--init`, otherwise the correct URL is taken from existing tag / compare entries.

Also the remoteUrls protocol does not need to be set by hand, since new URL() seems to parse the correct protocol from the URL.


I tested the implementation with these inputs:
```
    console.log(normalizeUrl("git@github.com:my/proj.git", true).href == "https://github.com/my/proj")
    console.log(normalizeUrl("git@github.com:my/proj", true).href == "https://github.com/my/proj")
    console.log(normalizeUrl("https://github.com/my/proj.git", true).href == "https://github.com/my/proj")
    console.log(normalizeUrl("https://github.com/my/proj", true).href == "https://github.com/my/proj")
    console.log(normalizeUrl("https://gitlab.example.com/my/proj.git", true).href == "https://gitlab.example.com/my/proj")
    console.log(normalizeUrl("https://gitlab.example.com/my/proj", true).href == "https://gitlab.example.com/my/proj")
    console.log(normalizeUrl("git@gitlab.example.com:my/proj.git", true).href == "https://gitlab.example.com/my/proj")
    console.log(normalizeUrl("git@gitlab.example.com:my/proj", true).href == "https://gitlab.example.com/my/proj")
    console.log(normalizeUrl("git@gitlab.example.com:my/proj", false).href == "http://gitlab.example.com/my/proj")
```

I think it would be a good idea to move `normalizeUrl` into the library code and add some unit tests, but I am not sure if you want this since this is only used in `bin.ts`