### PR TITLE
Skip release creation if it already exists

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -87,6 +87,16 @@ try {
 
   if (argv.create) {
     const version = typeof argv.create === "string" ? argv.create : undefined;
+
+    const release = changelog.releases.find((release) => {
+      return release.version === version
+    });
+
+    if (release) {
+      console.warn("Release already exists.");
+      Deno.exit(0);
+    }
+
     changelog.addRelease(new Release(version));
   }
 

--- a/bin.ts
+++ b/bin.ts
@@ -94,10 +94,9 @@ try {
 
     if (release) {
       console.warn("Release already exists.");
-      Deno.exit(0);
+    } else {
+      changelog.addRelease(new Release(version));
     }
-
-    changelog.addRelease(new Release(version));
   }
 
   save(file, changelog);


### PR DESCRIPTION
This fixes the `--create` option creating a new Unreleased section even if it already exists in the changelog.

I'm not sure what are the contribution rules are for this repository so feel free to provide feedback if needed.