### PR TITLE
Add Azure DevOps URL support

### DIFF
--- a/src/Changelog.ts
+++ b/src/Changelog.ts
@@ -13,7 +13,7 @@ export default class Changelog {
   tagNameBuilder?: (release: Release) => string;
   /** @deprecated: Use tagLinkBuilder() instead */
   compareLinkBuilder?: (previous: Release, release: Release) => string;
-  tagLinkBuilder?: (url: string, tag: string, previous?: string) => string;
+  tagLinkBuilder?: (url: string, tag: string, previous?: string, head?: string) => string;
   format: "compact" | "markdownlint" = "compact";
 
   constructor(title: string, description = "") {
@@ -53,17 +53,18 @@ export default class Changelog {
       const url = this.url!;
 
       if (!previous) {
-        return this.tagLinkBuilder(this.url!, this.tagName(release));
+        return this.tagLinkBuilder(this.url!, this.tagName(release), undefined, this.head);
       }
 
       if (!release.date || !release.version) {
-        return this.tagLinkBuilder(url, this.head, this.tagName(previous));
+        return this.tagLinkBuilder(url, this.head, this.tagName(previous), this.head);
       }
 
       return this.tagLinkBuilder(
         url,
         this.tagName(release),
         this.tagName(previous),
+        this.head,
       );
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,7 +83,7 @@ function processTokens(tokens: Token[], opts: Options): Changelog {
 
   while (link) {
     if (!changelog.url) {
-      const matches = link.match(/^\[.*\]\:\s*(http.*?)\/(?:-\/)?compare\/.*$/);
+      const matches = link.match(/^\[.*\]\:\s*(http.*?)\/(?:-\/)?(branchCompare|compare)(\/|\?).*$/);
 
       if (matches) {
         changelog.url = matches[1];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,7 +21,7 @@ class URLPatternShim {
 
 export interface Settings {
   pattern: URLPatternShim;
-  tagLink: (url: string, tag: string, previous?: string) => string;
+  tagLink: (url: string, tag: string, previous?: string, head?: string) => string;
   head: string;
 }
 
@@ -50,6 +50,23 @@ export const settings: Settings[] = [
       }
 
       return `${url}/-/compare/${previous}...${tag}`;
+    },
+  },
+  {
+    pattern: new URLPatternShim("https://dev.azure.com/*"),
+    head: "master",
+    tagLink(url, tag, previous, head) {
+      if (!previous) {
+        return `${url}?version=GT${tag}`;
+      }
+
+      let tagPrefix = "GT";
+
+      if (tag === head) {
+        tagPrefix = "GB";
+      }
+
+      return `${url}/branchCompare?baseVersion=GT${previous}&targetVersion=${tagPrefix}${tag}`;
     },
   },
 ];

--- a/test/changelog.azdo.md
+++ b/test/changelog.azdo.md
@@ -1,0 +1,24 @@
+# Changelog - Azure DevOps demo
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+- This is a brand new releases with:
+
+## [0.0.2] - 2023-11-09
+### Added
+- I want to have a compare link
+
+## [0.0.1] - 2023-11-09
+### Added
+- This is just a test changelog
+
+[Unreleased]: https://dev.azure.com/myorg/myproject/_git/myrepo/branchCompare?baseVersion=GTv0.0.2&targetVersion=GBmaster
+[0.0.2]: https://dev.azure.com/myorg/myproject/_git/myrepo/branchCompare?baseVersion=GTv0.0.1&targetVersion=GTv0.0.2
+[0.0.1]: https://dev.azure.com/myorg/myproject/_git/myrepo?version=GTv0.0.1
+
+---
+
+This is a footer

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -5,8 +5,10 @@ import getSettingsForURL from "../src/settings.ts";
 
 const file = new URL("./changelog.custom.type.md", import.meta.url).pathname;
 const fileGitlab = new URL("./changelog.gitlab.md", import.meta.url).pathname;
+const fileAzdo = new URL("./changelog.azdo.md", import.meta.url).pathname;
 const changelogContent = Deno.readTextFileSync(file);
 const changelogContentGitlab = Deno.readTextFileSync(fileGitlab);
+const changelogContentAzdo = Deno.readTextFileSync(fileAzdo);
 
 Deno.test("parser testing", function () {
   // is unable to parse changelog with unknown types
@@ -36,4 +38,24 @@ Deno.test("parser testing gitlab", function () {
   }
 
   assertEquals(changelog.toString().trim(), changelogContentGitlab.trim());
+});
+
+Deno.test("parser testing Azure DevOps", function () {
+  // parses a changelog with Azure DevOps links
+  const changelog = parser(changelogContentAzdo, );
+
+  // get settings from url
+  assert(changelog.url, "URL is not defined");
+
+  if(changelog.url) {
+    const settings = getSettingsForURL(changelog.url);
+    assert(settings)
+
+    if (settings) {
+      changelog.head = settings.head;
+      changelog.tagLinkBuilder = settings.tagLink;
+    }
+  }
+
+  assertEquals(changelog.toString().trim(), changelogContentAzdo.trim());
 });


### PR DESCRIPTION
Adds Azure DevOps URL format support.

I'm not particularly satisfied with the way I had to detect if `tag` match a branch or a tag. Azure DevOps needs to be told explicitly which it is (by using `GB` or `GT`, respectively) and what I've implemented will only work on the `unreleased` URL. I'm open to suggestions on how to handle this properly.