### PR TITLE
Bugfix: BitBucket URLs improperly parsed

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -94,7 +94,7 @@ function processTokens(tokens: Token[], opts: Options): Changelog {
   while (link) {
     if (!changelog.url) {
       const matches = link.match(
-        /^\[.*\]\:\s*(http.*?)\/(?:-\/)?(branchCompare|compare)(\/|\?).*$/,
+        /^\[.*\]\:\s*(http.*?)\/(?:-\/)?(branches\/compare|branchCompare|compare)(\/|\?).*$/,
       );
 
       if (matches) {

--- a/test/changelog.bitbucket.md
+++ b/test/changelog.bitbucket.md
@@ -15,10 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - This is just a test changelog
 
-[Unreleased]: https://bitbucket.org/organization/repo-name/branches/compare/master%0D0.0.2
-[0.0.2]: https://bitbucket.org/organization/repo-name/branches/compare/0.0.2%0D0.0.1
-[0.0.1]: https://bitbucket.org/organization/repo-name/src/0.0.1
-
+[Unreleased]: https://bitbucket.org/organization/repo-name/branches/compare/master%0Dv0.0.2
+[0.0.2]: https://bitbucket.org/organization/repo-name/branches/compare/v0.0.2%0Dv0.0.1
+[0.0.1]: https://bitbucket.org/organization/repo-name/src/v0.0.1
 
 ---
 

--- a/test/changelog.bitbucket.md
+++ b/test/changelog.bitbucket.md
@@ -1,0 +1,25 @@
+# Changelog - bitbucket demo
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+- This is a brand new releases with:
+
+## [0.0.2] - 2023-11-09
+### Added
+- I want to have a compare link
+
+## [0.0.1] - 2023-11-09
+### Added
+- This is just a test changelog
+
+[Unreleased]: https://bitbucket.org/organization/repo-name/branches/compare/master%0D0.0.2
+[0.0.2]: https://bitbucket.org/organization/repo-name/branches/compare/0.0.2%0D0.0.1
+[0.0.1]: https://bitbucket.org/organization/repo-name/src/0.0.1
+
+
+---
+
+This is a footer

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -3,14 +3,17 @@ import { parser } from "../mod.ts";
 import releaseCreator from "./fixture/CustomRelease.ts";
 import getSettingsForURL from "../src/settings.ts";
 
+https:\/\/bitbucket.org\/[^\/]+\/[^\/]+\/branches\/compare
 const file = new URL("./changelog.custom.type.md", import.meta.url).pathname;
 const fileGitlab = new URL("./changelog.gitlab.md", import.meta.url).pathname;
 const fileAzdo = new URL("./changelog.azdo.md", import.meta.url).pathname;
 const fileSort = new URL("./changelog.sort.md", import.meta.url).pathname;
+const fileBitbucket = new URL("./changelog.bitbucket.md", import.meta.url).pathname;
 const changelogContent = Deno.readTextFileSync(file);
 const changelogContentGitlab = Deno.readTextFileSync(fileGitlab);
 const changelogContentAzdo = Deno.readTextFileSync(fileAzdo);
 const changelogContentSort = Deno.readTextFileSync(fileSort);
+const changelogContentBitbucket = Deno.readTextFileSync(fileBitbucket);
 
 Deno.test("parser testing", function () {
   // is unable to parse changelog with unknown types
@@ -80,4 +83,24 @@ Deno.test("parser testing Azure DevOps", function () {
   }
 
   assertEquals(changelog.toString().trim(), changelogContentAzdo.trim());
+});
+
+Deno.test("parser testing BitBucket", function () {
+  // parses a changelog with Azure BitBucket links
+  const changelog = parser(changelogContentBitbucket, );
+
+  // get settings from url
+  assert(changelog.url, "URL is not defined");
+
+  if(changelog.url) {
+    const settings = getSettingsForURL(changelog.url);
+    assert(settings)
+
+    if (settings) {
+      changelog.head = settings.head;
+      changelog.tagLinkBuilder = settings.tagLink;
+    }
+  }
+
+  assertEquals(changelog.toString().trim(), changelogContentBitbucket.trim());
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -3,7 +3,6 @@ import { parser } from "../mod.ts";
 import releaseCreator from "./fixture/CustomRelease.ts";
 import getSettingsForURL from "../src/settings.ts";
 
-https:\/\/bitbucket.org\/[^\/]+\/[^\/]+\/branches\/compare
 const file = new URL("./changelog.custom.type.md", import.meta.url).pathname;
 const fileGitlab = new URL("./changelog.gitlab.md", import.meta.url).pathname;
 const fileAzdo = new URL("./changelog.azdo.md", import.meta.url).pathname;


### PR DESCRIPTION
Hey,

It's me again.

I found a bug in the parsing of BitBucket comparison URLs.

The comparison URLs of BitBucket follow this structure:

```
https://bitbucket.org/<org-name>/<repo-name>/branches/compare/<NewTag>%D0<OldTag>
```

The `/branches` part was not removed during URL parsing, leading to another `/branches` part being added every time the tool was run, like this:

```
https://bitbucket.org/<org-name>/<repo-name>/branches/compare/<NewTag>%D0<OldTag>
https://bitbucket.org/<org-name>/<repo-name>/branches/branches/compare/<NewTag>%D0<OldTag>
https://bitbucket.org/<org-name>/<repo-name>/branches/branches/branches/compare/<NewTag>%D0<OldTag>
...
```

This bugfix should fix this problem.

Thanks for taking a look!