### PR TITLE
fix: npx executable

### DIFF
--- a/_scripts/build_npm.ts
+++ b/_scripts/build_npm.ts
@@ -147,6 +147,9 @@ Deno.copyFileSync("LICENSE", "_npm/LICENSE");
 Deno.copyFileSync("README.md", "_npm/README.md");
 Deno.copyFileSync("CHANGELOG.md", "_npm/CHANGELOG.md");
 
+// Make bin.js executable
+await Deno.chmod("_npm/bin.js", 0o755);
+
 // Run Deno to format the code
 await new Deno.Command("deno", {
   args: ["fmt", "--unstable-components", "."],

--- a/bin.ts
+++ b/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { cwd, exit } from "node:process";


### PR DESCRIPTION
Add shebang and make the npm binary executable so that package can be run using `npx keep-a-changelog`