### PR TITLE
Keep parser as value import in npm declarations

### DIFF
--- a/_scripts/build_npm.ts
+++ b/_scripts/build_npm.ts
@@ -104,7 +104,7 @@ for await (const { path } of walk("_npm", { exts: [".js"] })) {
 for await (const { path } of walk("_npm", { exts: [".ts"] })) {
   let code = Deno.readTextFileSync(path)
     .replaceAll(/\.ts";/g, '.d.ts";')
-    .replaceAll(/import ([A-Z]|p)/g, 'import type $1')
+    .replaceAll(/import ([A-Z])/g, 'import type $1')
 
   for (const [name, version] of Object.entries(dependencies)) {
     code = code.replaceAll(`npm:${name}@${version}`, name);


### PR DESCRIPTION
## Summary

- stop the npm build script from rewriting the lowercase `parser` import to `import type`
- continue rewriting uppercase class imports (`Change`, `Changelog`, `Release`) to `import type`

This should address the follow-up in #67 where `parser` resolves as type-only in the generated npm declarations and therefore cannot be used as a value.

## Verification

- static simulation of the declaration rewrite confirms `import parser from ...` remains a value import while `import Change from ...` becomes `import type Change from ...`
- `git diff --check`

I could not run `deno task build-npm` locally because `deno` is not installed in this environment.

I used an AI coding assistant to prepare this patch.

Fixes #67
